### PR TITLE
Fix wrong id being assigned to article when storing cacheTags

### DIFF
--- a/Joomla5/lscache_plugin/lscache.php
+++ b/Joomla5/lscache_plugin/lscache.php
@@ -142,8 +142,10 @@ class plgSystemLSCache extends CMSPlugin {
                 $this->cacheTags[] = "com_menus:" . $menuid;
             }
             $this->pageElements = $this->menuItem->query;
-            if (empty($this->pageElements["option"]) && (!empty($app->input->get('option')))) {
+            if (!empty($app->input->get('option'))) {
                 $this->pageElements["option"] = $app->input->get('option');
+				$this->pageElements["view"] = $app->input->get('view');
+				$this->pageElements["id"] = $app->input->get('id');
             }
         } else {
             $link = JUri::getInstance()->getQuery();


### PR DESCRIPTION
The current code is wrong because the id assigned to the cacheTags depends on the menu item.

This means that if an article belongs to a Category List menu item, for example, the id assigned in the cacheTags for each article is the id of the category instead of the id of the article.

This causes the article cache to not be purged when saving the article, because the assigned id is wrong.

This pull request fixes the issue.