### PR TITLE
Fix for com_contact items not getting purged when saved

### DIFF
--- a/Joomla5/lscache_plugin/lscache.php
+++ b/Joomla5/lscache_plugin/lscache.php
@@ -28,7 +28,7 @@ class plgSystemLSCache extends CMSPlugin {
     const MODULE_EMBED = 4;
     const CATEGORY_CONTEXTS = array('com_categories.category', 'com_banners.category', 'com_contact.category', 'com_content.category', 'com_newsfeeds.category', 'com_users.category',
         'com_categories.categories', 'com_banners.categories', 'com_contact.categories', 'com_content.categories', 'com_newsfeeds.categories', 'com_users.categories');
-    const CONTENT_CONTEXTS = array('com_content.article', 'com_content.featured', 'com_content.form', 'com_banner.banner', 'com_contact.contact', 'com_newsfeeds.newsfeed', 'com_content');
+    const CONTENT_CONTEXTS = array('com_content.article', 'com_content.featured', 'com_content.form', 'com_banner.banner', 'com_contact.contact', 'com_contact.form', 'com_newsfeeds.newsfeed', 'com_content');
 
     protected $app;
     protected $cacheEnabled;


### PR DESCRIPTION
This PR fixes com_contact items not getting purged when saved.

This was due to the 'com_contact.form' being missing from the const CONTENT_CONTEXTS.