### PR TITLE
Pr/joomla5 esi rsform

### DIFF
--- a/Joomla5/lscache_plugin/lscache.php
+++ b/Joomla5/lscache_plugin/lscache.php
@@ -294,22 +294,27 @@ class plgSystemLSCache extends CMSPlugin {
 
                 $language = '';
                 if ($module->vary_language) {
-                    $language = '&language=' . Factory::getLanguage()->getTag();
+                    $language = Factory::getLanguage()->getTag();
                 }
+
+                $pageUrl = !empty($module->lscache_pageurl) ? $this->getCurrentPageUrl() : '';
+                $url = $this->getESIModuleUrl($module->id, $device, $language, $attribs, $pageUrl);
                 
                 if ($module->lscache_type == 1) {
-                    $module->content = '<esi:include src="index.php?option=com_lscache&moduleid=' . $module->id . '&device=' . $device . $language . $this->getModuleAttribs($attribs) . '" cache-control="public,no-vary" cache-tag="' . $tag . '" />';
+                    $module->content = '<esi:include src="' . $url . '" cache-control="public,no-vary" cache-tag="' . $tag . '" />';
                 } else if ($module->lscache_type == -1) {
                     $tag = 'public:' . $tag . ',' . $tag;
-                    $module->content = '<esi:include src="index.php?option=com_lscache&moduleid=' . $module->id . '&device=' . $device . $language  . Factory::getLanguage()->getTag() . $this->getModuleAttribs($attribs) . '" cache-control="private,no-vary" cache-tag="' . $tag . '" />';
-                } else if ($module->lscache_type == 0) {
-                    $module->content = '<esi:include src="' . 'index.php?option=com_lscache&moduleid=' . $module->id . '&device=' . $device . $language . $this->getModuleAttribs($attribs) . '" cache-control="no-cache"/>';
+                    $module->content = '<esi:include src="' . $url . '" cache-control="private,no-vary" cache-tag="' . $tag . '" />';
+                } else {
+                    $module->content = '<esi:include src="' . $url . '" cache-control="no-cache"/>';
                 }
 
                 $this->esion = true;
                 return;
             } else if (!LITESPEED_ESI_SUPPORT) {
-                $url = 'index.php?option=com_lscache&moduleid=' . $module->id . '&device=' . $device . '&language=' . Factory::getLanguage()->getTag() . $this->getModuleAttribs($attribs) ;
+                $language = $module->vary_language ? Factory::getLanguage()->getTag() : '';
+                $pageUrl = !empty($module->lscache_pageurl) ? $this->getCurrentPageUrl() : '';
+                $url = $this->getESIModuleUrl($module->id, $device, $language, $attribs, $pageUrl);
                 $js = '$.ajax({url: "' . $url .'", success: function(result){' . PHP_EOL ;
                 $js .= '    $("#lscache_mod' . $module->id . '").replaceWith(result);' . PHP_EOL ;
                 $js .= '}});' .PHP_EOL ;
@@ -1428,24 +1433,38 @@ class plgSystemLSCache extends CMSPlugin {
             $attribs = $this->explode2($attrib, ';', ',');
         }
 
+        $requestedMenuid = $app->input->getInt('Itemid', 0);
         $menuid = $app->getMenu()->getDefault()->id;
+        $pageContext = array();
 
-        if (($module->pages > 0) && (isset($_SERVER['HTTP_REFERER']))) {
+        if ($requestedMenuid > 0) {
+            $menuid = $requestedMenuid;
+            $pageContext = $this->getMenuPageContext($menuid);
             $uri = Uri::getinstance();
             $uri->setPath("");
             $uri->setQuery("");
-            $uri->setFragment(""); 
+            $uri->setFragment("");
+            $url = Route::_('index.php?Itemid=' . $menuid, false);
+            $uri->parse($url);
+        } else if (($module->pages > 0) && (isset($_SERVER['HTTP_REFERER']))) {
+            $uri = Uri::getinstance();
+            $uri->setPath("");
+            $uri->setQuery("");
+            $uri->setFragment("");
             $uri->parse($_SERVER['HTTP_REFERER']);
 
-            $appInstance = Factory::getContainer()->get(SiteApplication::class);
-            $router = $appInstance->getRouter();
+            $router = $app->getRouter();
             $uri1 = clone $uri;
             $result = $router->parse($uri1);
+            if (is_array($result)) {
+                $pageContext = $result;
+            }
             if (isset($result['Itemid'])) {
                 $menuid = $result['Itemid'];
             }
         } else if (($module->pages > 0) && ($menuItems = $this->getModuleMenuItems($moduleid)) && (!in_array($menuid, $menuItems))) {
             $menuid = $menuItems[0];
+            $pageContext = $this->getMenuPageContext($menuid);
             $uri = Uri::getinstance();
             $uri->setPath("");
             $uri->setQuery("");
@@ -1453,6 +1472,7 @@ class plgSystemLSCache extends CMSPlugin {
             $url = Route::_('index.php?Itemid=' . $menuid, FALSE);
             $uri->parse($url);
         } else {
+            $pageContext = $this->getMenuPageContext($menuid);
             $root = Uri::root();
             $config = Factory::getConfig();
             $sef_rewrite = $config->get('sef_rewrite');
@@ -1467,13 +1487,20 @@ class plgSystemLSCache extends CMSPlugin {
             $uri->parse($root);
         }
 
+        $pageContext['Itemid'] = $menuid;
+        $this->applyESIPageContext($pageContext);
+        $app->input->set('Itemid', $menuid);
         $app->getMenu()->setActive($menuid);
 
         $lang = Factory::getLanguage();
         $language = $app->input->get('language');
-        if ($language && ($language!=$lang->getTag())) {
-            $lang->setDefault( $language );
-            $lang->load();
+        if ($language && ($language != $lang->getTag())) {
+            if (method_exists($lang, 'setLanguage')) {
+                $lang->setLanguage($language);
+                $lang->load();
+            } else {
+                $lang->load('', JPATH_SITE, $language, true, false);
+            }
         }
         $moduleLanguage = strtolower($module->module);
         $lang->load($moduleLanguage, JPATH_SITE);
@@ -1493,15 +1520,19 @@ class plgSystemLSCache extends CMSPlugin {
 
             $this->moduleHelper->afterESIRender($module, $content);
 
-            $cacheTimeout = $module->lscache_ttl * 60;
-            $this->lscInstance->config(array("public_cache_timeout" => $cacheTimeout, "private_cache_timeout" => $cacheTimeout));
-            if ($module->lscache_type == 1) {
-                $this->lscInstance->cachePublic($tag);
-                $this->log();
-            } else if ($module->lscache_type == -1) {
-                $this->lscInstance->checkPrivateCookie();
-                $this->lscInstance->cachePrivate($tag, $tag);
-                $this->log();
+            if ($module->lscache_type == 0) {
+                header('X-LiteSpeed-Cache-Control: no-cache');
+            } else {
+                $cacheTimeout = $module->lscache_ttl * 60;
+                $this->lscInstance->config(array("public_cache_timeout" => $cacheTimeout, "private_cache_timeout" => $cacheTimeout));
+                if ($module->lscache_type == 1) {
+                    $this->lscInstance->cachePublic($tag);
+                    $this->log();
+                } else if ($module->lscache_type == -1) {
+                    $this->lscInstance->checkPrivateCookie();
+                    $this->lscInstance->cachePrivate($tag, $tag);
+                    $this->log();
+                }
             }
             
             if ($module->module_type == 0) {                
@@ -1516,6 +1547,94 @@ class plgSystemLSCache extends CMSPlugin {
                 $this->app->setTemplate('esitemplate');
             }
         }
+    }
+
+    private function getCurrentMenuItemId() {
+        if ($this->menuItem && isset($this->menuItem->id)) {
+            return (int) $this->menuItem->id;
+        }
+
+        return (int) $this->app->input->getInt('Itemid', 0);
+    }
+
+    private function getCurrentPageUrl() {
+        $uri = Uri::getInstance();
+        $pageUrl = $uri->toString(array('path', 'query'));
+
+        if ($pageUrl === '') {
+            return '/';
+        }
+
+        return $pageUrl;
+    }
+
+    private function getMenuPageContext($menuid) {
+        $menuid = (int) $menuid;
+        if ($menuid <= 0) {
+            return array();
+        }
+
+        $menu = $this->app->getMenu()->getItem($menuid);
+        if (!$menu) {
+            return array('Itemid' => $menuid);
+        }
+
+        $context = array();
+        if (isset($menu->query) && is_array($menu->query)) {
+            $context = $menu->query;
+        } else if (isset($menu->query) && is_object($menu->query)) {
+            $context = get_object_vars($menu->query);
+        }
+
+        $context['Itemid'] = $menuid;
+        return $context;
+    }
+
+    private function applyESIPageContext(array $pageContext) {
+        $reserved = array(
+            'moduleid' => true,
+            'device' => true,
+            'attribs' => true,
+            'cleanCache' => true,
+            'recache' => true,
+        );
+
+        foreach ($pageContext as $key => $value) {
+            if ($key === '' || isset($reserved[$key])) {
+                continue;
+            }
+
+            if (is_scalar($value) || $value === null) {
+                $this->app->input->set($key, $value);
+            }
+        }
+    }
+
+    public function getESIPageUrlParam() {
+        return rawurldecode($this->app->input->get('pageurl', '', 'raw'));
+    }
+
+    private function getESIModuleUrl($moduleid, $device, $language = '', array $attribs = array(), $pageUrl = '') {
+        $params = array(
+            'option' => 'com_lscache',
+            'moduleid' => (int) $moduleid,
+            'device' => $device,
+        );
+
+        $menuid = $this->getCurrentMenuItemId();
+        if ($menuid > 0) {
+            $params['Itemid'] = $menuid;
+        }
+
+        if ($language !== '') {
+            $params['language'] = $language;
+        }
+
+        if ($pageUrl !== '') {
+            $params['pageurl'] = rawurlencode($pageUrl);
+        }
+
+        return 'index.php?' . $this->implode2($params, '&', '=') . $this->getModuleAttribs($attribs);
     }
 
     private function getModuleAttribs(array $attribs) {

--- a/Joomla5/lscache_plugin/modules/list.php
+++ b/Joomla5/lscache_plugin/modules/list.php
@@ -10,6 +10,7 @@
 $lscacheModules = Array(
     "mod_menu" => Array("Joomla.mod_menu", "mod_menu", "joomla.menu.php", "LSCacheModuleJoomlaMenu"),
     "mod_k2_content" => Array("K2.mod_k2_content", "mod_k2_content", "k2.content.php", "LSCacheModuleK2Content"),
+    "mod_rsform" => Array("RSForm.mod_rsform", "mod_rsform", "rsform.php", "LSCacheModuleRSForm"),
     "mod_virtuemart_cart" => Array("VirtueMart.mod_virtuemart_cart", "mod_virtuemart_cart", "virtuemart.cart.php", "LSCacheModuleVirtueMartCart"),
     
 );

--- a/Joomla5/lscache_plugin/modules/rsform.php
+++ b/Joomla5/lscache_plugin/modules/rsform.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ *  @since      1.1
+ *  @author     LiteSpeed Technologies <info@litespeedtech.com>
+ *  @copyright  Copyright (c) 2017-2018 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ *  @license    https://opensource.org/licenses/GPL-3.0
+ */
+
+class LSCacheModuleRSForm extends LSCacheModuleBase
+{
+    public function getModuleTags(){
+        if ($this->plugin->getModuleCacheType($this->module) == plgSystemLSCache::MODULE_ESI) {
+            $this->module->lscache_type = 0;
+            $this->module->module_type = 0;
+            $this->module->lscache_pageurl = 1;
+        }
+
+        return "";
+    }
+
+    public function afterESIRender(&$content){
+        $pageUrl = $this->plugin->getESIPageUrlParam();
+        if ($pageUrl === '') {
+            return;
+        }
+
+        $content = preg_replace_callback(
+            '/<form\b[^>]*\baction="[^"]*"/i',
+            function ($matches) use ($pageUrl) {
+                return preg_replace('/action="[^"]*"/i', 'action="' . htmlspecialchars($pageUrl, ENT_COMPAT, 'UTF-8') . '"', $matches[0], 1);
+            },
+            $content
+        );
+    }
+}


### PR DESCRIPTION
Closes #78

## Summary

This fixes Joomla 5 advanced ESI module rendering when the ESI subrequest loses the original page context.

In practice this was breaking context-sensitive modules, with RSForm as the reproducible case:
- ESI subrequests could not reliably resolve the originating page/menu context
- Joomla 5 hit removed or changed language/request behavior in the ESI path
- form modules could render with the wrong submit action and unsafe cache behavior

## Changes

### Core Joomla 5 ESI request fixes
- preserve `Itemid` in generated ESI module URLs
- restore page context for ESI subrequests from `Itemid`, referer parsing, or assigned menu items
- use the current Joomla app/router in the ESI path
- make language switching compatible with Joomla 5 where `setLanguage()` is no longer available
- generate ESI and AJAX module URLs consistently, including optional outer page URL propagation
- return `X-LiteSpeed-Cache-Control: no-cache` for ESI fragments whose effective `lscache_type` is `0`

### RSForm helper integration
- add a dedicated `mod_rsform` helper
- force RSForm ESI fragments to render as `no-cache`
- pass the outer page URL through the ESI request
- rewrite the rendered form action back to the outer page route

## Why RSForm is handled separately

The core issue is broader than RSForm: Joomla 5 advanced ESI requests need the original page context restored.

RSForm is added as a module helper because form modules also need extension-specific handling:
- their fragment must not be publicly cached
- their rendered form action must point to the outer page, not the internal `com_lscache` endpoint

## Validation

Validated on Joomla 5 with an RSForm module configured as ESI:
- main page remains LSCache-cached
- ESI fragment renders successfully
- fragment responds with `X-LiteSpeed-Cache-Control: no-cache`
- form action points to the outer page route
- form submissions are written successfully
- separate sessions receive fresh form fragments instead of a shared cached tokenized fragment