### PR TITLE
fix: PHP 8.0-8.5 and Joomla 5/6 compatibility fixes (bugs, security, …

### DIFF
--- a/Joomla5/lscache_plugin/components/com_komento.php
+++ b/Joomla5/lscache_plugin/components/com_komento.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types=1);
 
-/* 
+/*
  *  @since      1.0.0
  *  @author     LiteSpeed Technologies <info@litespeedtech.com>
  *  @copyright  Copyright (c) 2017-2018 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
@@ -44,11 +45,12 @@ class LSCacheComponentKomento extends LSCacheComponentBase{
     }
     
     protected function purgeComment($ids){
+            $ids = array_map('intval', $ids);
             $db = Factory::getDbo();
             $query = $db->createQuery()
                     ->select("distinct component, cid")
                     ->from('#__komento_comments')
-                    ->where($db->quoteName('id') . ' in (' . implode(',', $ids) . ')');
+                    ->where($db->quoteName('id') . ' IN (' . implode(',', $ids) . ')');
             $db->setQuery($query);
             $comments = $db->loadObjectList();
             foreach($comments as $comment){

--- a/Joomla5/lscache_plugin/components/com_virtuemart.php
+++ b/Joomla5/lscache_plugin/components/com_virtuemart.php
@@ -85,7 +85,8 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
     public function plgVmAfterStoreProduct($data, $product_data=null)
     {
         if($data instanceof Event) {
-            return $this->plgVmOnDeleteProduct($data->getArgument('0'), $data->getArgument('1'));
+            $product_data = $data->getArgument('1');
+            $data = $data->getArgument('0');
         }
 
         $category_tag = $this->getProductCategoryTags($product_data->virtuemart_product_id);
@@ -158,7 +159,7 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
             $this->plugin->purgeAction();
             return;
         }
-        $urls = $this->getProductCategoryUrls($id);
+        $urls = $this->getProductCategoryUrls($productids);
         $this->plugin->purgeObject->urls = array_merge($urls, $productUrls);
         $this->plugin->purgeAction();
     }
@@ -190,7 +191,7 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
         if ($context == "com_virtuemart.productdetails") {
             return 'com_virtuemart.product:' . $pageElements['content']->virtuemart_product_id;
         } else if ($context == "com_virtuemart.category") {
-            if (isset($pageElements["content"]) & !empty($pageElements["content"]->virtuemart_category_id)) {
+            if (isset($pageElements["content"]) && !empty($pageElements["content"]->virtuemart_category_id)) {
                 return 'com_virtuemart.category:' . $pageElements["content"]->virtuemart_category_id;
             }
             return $option;
@@ -206,8 +207,8 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
                 ->select($db->quoteName(array('virtuemart_category_id', 'virtuemart_product_id')))
                 ->from('#__virtuemart_product_categories');
         if (is_array($productid)) {
-            $products = implode(',', $productid);
-            $query->where($db->quoteName('virtuemart_product_id') . ' in (' . $products . ')');
+            $products = implode(',', array_map('intval', $productid));
+            $query->where($db->quoteName('virtuemart_product_id') . ' IN (' . $products . ')');
         } else {
             $query->where($db->quoteName('virtuemart_product_id') . '=' . (int) $productid);
         }
@@ -302,6 +303,10 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
     public function onContentPrepare($context, $row=null, $params=null, $page = 0) {
         if($context instanceof Event) {
             return $this->onContentPrepare($context->getArgument(0),$context->getArgument(1),$context->getArgument(2),$context->getArgument(3));
+        }
+
+        if (!class_exists('VmModel')) {
+            return;
         }
 
         $productModel = VmModel::getModel('Product');

--- a/Joomla5/lscache_plugin/lscache.php
+++ b/Joomla5/lscache_plugin/lscache.php
@@ -92,7 +92,7 @@ class plgSystemLSCache extends CMSPlugin {
         }
 
         // Checks if caching is allowed via server variable
-        if (!empty($_SERVER['X-LSCACHE']) || LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_ADC' || defined('LITESPEED_CLI')) {
+        if (!empty($_SERVER['HTTP_X_LSCACHE']) || LITESPEED_SERVER_TYPE === 'LITESPEED_SERVER_ADC' || defined('LITESPEED_CLI')) {
             !defined('LITESPEED_ALLOWED') && define('LITESPEED_ALLOWED', true);
         }
 
@@ -101,20 +101,20 @@ class plgSystemLSCache extends CMSPlugin {
             define('LITESPEED_ESI_SUPPORT', LITESPEED_SERVER_TYPE !== 'LITESPEED_SERVER_OLS' ? true : false );
         }
 
-        JLoader::register('LiteSpeedCacheBase', __DIR__ . '/lscachebase.php', true);
-        JLoader::register('LiteSpeedCacheCore', __DIR__ . '/lscachecore.php', true);
+        require_once __DIR__ . '/lscachebase.php';
+        require_once __DIR__ . '/lscachecore.php';
         $this->lscInstance = new LiteSpeedCacheCore();
 
-        JLoader::register('LSCacheModuleBase', __DIR__ . '/modules/base.php', true);
-        JLoader::register('LSCacheModulesHelper', __DIR__ . '/modules/helper.php', true);
+        require_once __DIR__ . '/modules/base.php';
+        require_once __DIR__ . '/modules/helper.php';
         $this->moduleHelper = new LSCacheModulesHelper($this);
 
         if (!$this->app) {
             $this->app = Factory::getApplication();
         }
 
-        JLoader::register('LSCacheComponentBase', __DIR__ . '/components/base.php', true);
-        JLoader::register('LSCacheComponentsHelper', __DIR__ . '/components/helper.php', true);
+        require_once __DIR__ . '/components/base.php';
+        require_once __DIR__ . '/components/helper.php';
         $this->componentHelper = new LSCacheComponentsHelper($this);
 
         $this->purgeObject = (object) array('tags' => array(), 'urls' => array(), 'option' => "", 'idField' => "", 'ids' => array(), 'purgeAll' => false, 'recacheAll' => false);
@@ -607,6 +607,7 @@ class plgSystemLSCache extends CMSPlugin {
         }
         
         $option = $this->getOption($context);
+        $purgeTags = '';
 
         $menu_contexts = array('com_menus.item', 'com_menus.menu');
         if (in_array($context, $menu_contexts)) {
@@ -1029,12 +1030,17 @@ class plgSystemLSCache extends CMSPlugin {
         $extensionID = $this->pageElements["id"];
         $file = $this->pageElements["file"];
         if ($purge && !empty($file) && !empty($extensionID)) {
-            $file = base64_decode($file);
-            $elements = explode('/', $file);
-            if (count($elements) < 3) {
+            $decoded = base64_decode($file, true);
+            if ($decoded === false || str_contains($decoded, '..') || str_contains($decoded, "\0")) {
                 $purge = false;
-            } else if ($elements[1] != "html") {
-                $purge = false;
+            } else {
+                $file = $decoded;
+                $elements = explode('/', $file);
+                if (count($elements) < 3) {
+                    $purge = false;
+                } else if ($elements[1] !== "html") {
+                    $purge = false;
+                }
             }
         }
 
@@ -1137,7 +1143,7 @@ class plgSystemLSCache extends CMSPlugin {
         $query = $db->createQuery()
                 ->select('*')
                 ->from('#__modules')
-                ->where($db->quoteName('module') . '="' . $element . '"')
+                ->where($db->quoteName('module') . '=' . $db->quote($element))
                 ->where($db->quoteName('published') . '=1');
 
         $db->setQuery($query);
@@ -1152,7 +1158,7 @@ class plgSystemLSCache extends CMSPlugin {
         $query = $db->createQuery()
                 ->select('*')
                 ->from('#__template_styles')
-                ->where($db->quoteName('template') . '="' . $element . '"');
+                ->where($db->quoteName('template') . '=' . $db->quote($element));
 
         $db->setQuery($query);
 
@@ -1360,7 +1366,7 @@ class plgSystemLSCache extends CMSPlugin {
         $cleancache = $app->input->get('cleanCache');
         if($ipPass && (!empty($cleancache))) {
             $cleanWords = $this->settings->get('cleanCache', 'purgeAllCache');
-            if ($cleancache != $cleanWords) {
+            if ($cleancache !== $cleanWords) {
                 http_response_code(403);
                 $app->close();
                 return;
@@ -1382,7 +1388,7 @@ class plgSystemLSCache extends CMSPlugin {
         $recache = $app->input->get('recache');
         if ($ipPass && (!empty($recache))) {
             $cleanWords = $this->settings->get('cleanCache', 'purgeAllCache');
-            if ($recache != $cleanWords) {
+            if ($recache !== $cleanWords) {
                 http_response_code(403);
                 $app->close();
                 return;
@@ -1440,14 +1446,14 @@ class plgSystemLSCache extends CMSPlugin {
         if ($requestedMenuid > 0) {
             $menuid = $requestedMenuid;
             $pageContext = $this->getMenuPageContext($menuid);
-            $uri = Uri::getinstance();
+            $uri = Uri::getInstance();
             $uri->setPath("");
             $uri->setQuery("");
             $uri->setFragment("");
             $url = Route::_('index.php?Itemid=' . $menuid, false);
             $uri->parse($url);
         } else if (($module->pages > 0) && (isset($_SERVER['HTTP_REFERER']))) {
-            $uri = Uri::getinstance();
+            $uri = Uri::getInstance();
             $uri->setPath("");
             $uri->setQuery("");
             $uri->setFragment("");
@@ -1465,7 +1471,7 @@ class plgSystemLSCache extends CMSPlugin {
         } else if (($module->pages > 0) && ($menuItems = $this->getModuleMenuItems($moduleid)) && (!in_array($menuid, $menuItems))) {
             $menuid = $menuItems[0];
             $pageContext = $this->getMenuPageContext($menuid);
-            $uri = Uri::getinstance();
+            $uri = Uri::getInstance();
             $uri->setPath("");
             $uri->setQuery("");
             $uri->setFragment("");
@@ -1480,7 +1486,7 @@ class plgSystemLSCache extends CMSPlugin {
                 $root .= 'index.php';
             }
 
-            $uri = Uri::getinstance();
+            $uri = Uri::getInstance();
             $uri->setPath("");
             $uri->setQuery("");
             $uri->setFragment("");
@@ -1776,6 +1782,7 @@ class plgSystemLSCache extends CMSPlugin {
     }
 
     private function crawlUrls($urls, $output = true) {
+        $prevTimeLimit = (int) ini_get('max_execution_time');
         set_time_limit(0);
 
         $cli = false;
@@ -1841,7 +1848,6 @@ class plgSystemLSCache extends CMSPlugin {
             
             $buffer = curl_exec($ch);
             $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            curl_close($ch);
             $this->log( $root.$url);
 
             if (in_array($httpcode, $acceptCode)) {
@@ -1881,7 +1887,7 @@ class plgSystemLSCache extends CMSPlugin {
             usleep(round($diff));
         }
 
-        if($output & (!$break)){
+        if($output && (!$break)){
             echo '100%';
             if (ob_get_contents()){
                 ob_flush();
@@ -1894,6 +1900,9 @@ class plgSystemLSCache extends CMSPlugin {
             $msg = str_replace('%d', $totalTime, Text::_('COM_LSCACHE_PLUGIN_PAGERECACHED'));
         } else {
             $msg = str_replace('%d', $totalTime, Text::_('COM_LSCACHE_PLUGIN_PAGERECACHOVERTIME'));
+        }
+        if ($prevTimeLimit > 0) {
+            set_time_limit($prevTimeLimit);
         }
         return $msg;
     }
@@ -1910,6 +1919,7 @@ class plgSystemLSCache extends CMSPlugin {
             return;
         }
 
+        $httpcode = 0;
         if ((!$this->purgeObject->purgeAll) && ($this->purgeObject->autoRecache > 0)) {
             $root = Uri::root();
             $cleanWords = $this->settings->get('cleanCache', 'purgeAllCache');
@@ -1927,7 +1937,6 @@ class plgSystemLSCache extends CMSPlugin {
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             $buffer = curl_exec($ch);
             $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            curl_close($ch);
         }
 
         if (!empty($httpcode) && in_array($httpcode, array(200, 201))) {
@@ -2054,26 +2063,12 @@ class plgSystemLSCache extends CMSPlugin {
 
    
     protected function getVisitorIP() {
-        $ip = '';
+        // Use only REMOTE_ADDR for security-sensitive IP checks (admin whitelist).
+        // HTTP_CLIENT_IP and HTTP_X_FORWARDED_FOR are client-controlled and can
+        // be spoofed to bypass IP restrictions.
         $jinput = Factory::getApplication()->input;
-        $ip = $jinput->server->get('REMOTE_ADDR');
-        
-        if ($jinput->server->get('HTTP_CLIENT_IP')) {
-            $ip = $jinput->server->get('HTTP_CLIENT_IP');
-        } else if($jinput->server->get('HTTP_X_FORWARDED_FOR')) {
-            $ip = $jinput->server->get('HTTP_X_FORWARDED_FOR');
-        } else if($jinput->server->get('HTTP_X_FORWARDED')) {
-            $ip = $jinput->server->get('HTTP_X_FORWARDED');
-        } else if($jinput->server->get('HTTP_FORWARDED_FOR')) {
-            $ip = $jinput->server->get('HTTP_FORWARDED_FOR');
-        } else if($jinput->server->get('HTTP_FORWARDED')) {
-            $ip = $jinput->server->get('HTTP_FORWARDED');
-        } else if($jinput->server->get('REMOTE_ADDR')) {
-            $ip = $jinput->server->get('REMOTE_ADDR');
-        } else if (getHostName()){
-            $ip = getHostByName(getHostName());
-        }
-        return $ip;
+        $ip = $jinput->server->getString('REMOTE_ADDR', '');
+        return filter_var($ip, FILTER_VALIDATE_IP) ? $ip : '';
     }
     
     protected function esiTokenForm(){

--- a/Joomla5/lscache_plugin/lscachebase.php
+++ b/Joomla5/lscache_plugin/lscachebase.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * General function of communicating with LSWS Server for LSCache operations,
@@ -64,7 +65,7 @@ class LiteSpeedCacheBase
                         
             $tagStr = $prefix . trim($tag);
             if(!in_array($tagStr, $tagArray, false)){
-                array_push($tagArray, $tagStr);
+                $tagArray[] = $tagStr;
             }
         }
     }
@@ -197,7 +198,7 @@ class LiteSpeedCacheBase
             $this->tagsForSite($siteTags, $privateTags);
         }
         else{
-            array_push($siteTags,  'pvt');
+            $siteTags[] = 'pvt';
         }
         
         $LSheader = $this->tagCommand( self::CACHE_TAG ,  $siteTags);
@@ -239,19 +240,19 @@ class LiteSpeedCacheBase
     {
         if ($value == "") {
             if (isset($_COOKIE[self::VARY_COOKIE])) {
-                setcookie(self::VARY_COOKIE, "", '0', $path);
+                setcookie(self::VARY_COOKIE, "", 0, $path);
                 return false;
             }
             return true;
         }
         
         if(!isset($_COOKIE[self::VARY_COOKIE])){
-            setcookie(self::VARY_COOKIE, $value, '0', $path);
+            setcookie(self::VARY_COOKIE, $value, 0, $path);
             return false;
         }
 
         if($_COOKIE[self::VARY_COOKIE] != $value){
-            setcookie(self::VARY_COOKIE, $value, '0', $path);
+            setcookie(self::VARY_COOKIE, $value, 0, $path);
             return false;
         }
         

--- a/Joomla5/lscache_plugin/lscachecore.php
+++ b/Joomla5/lscache_plugin/lscachecore.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Core function of communicating with LSWS Server for LSCache operations
@@ -59,7 +60,7 @@ class LiteSpeedCacheCore extends LiteSpeedCacheBase
                         
             $tagStr = $prefix . $this->site_only_tag . trim($tag);
             if(!in_array($tagStr, $tagArray, false)){
-                array_push($tagArray, $tagStr);
+                $tagArray[] = $tagStr;
             }
         }
     }
@@ -107,7 +108,7 @@ class LiteSpeedCacheCore extends LiteSpeedCacheBase
         $this->liteSpeedHeader($LSheader);
 
         $siteTags = Array();
-        array_push($siteTags, $this->site_only_tag);
+        $siteTags[] = $this->site_only_tag;
         $this->tagsForSite($siteTags, $publicTags);
 
         $LSheader = $this->tagCommand( self::CACHE_TAG ,  $siteTags);
@@ -137,11 +138,11 @@ class LiteSpeedCacheCore extends LiteSpeedCacheBase
         $siteTags = Array();
         $this->tagsForSite($siteTags, $publicTags, "public:".$this->site_only_tag);
         if($publicTags!=""){
-            array_push($siteTags, "public:" . $this->site_only_tag);
+            $siteTags[] = "public:" . $this->site_only_tag;
         }
-        
+
         $this->tagsForSite($siteTags, $privateTags);
-        array_push($siteTags, $this->site_only_tag);
+        $siteTags[] = $this->site_only_tag;
         
         $LSheader = $this->tagCommand( self::CACHE_TAG ,  $siteTags);
         $this->liteSpeedHeader($LSheader);

--- a/Joomla6/lscache_plugin/components/com_komento.php
+++ b/Joomla6/lscache_plugin/components/com_komento.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types=1);
 
-/* 
+/*
  *  @since      1.0.0
  *  @author     LiteSpeed Technologies <info@litespeedtech.com>
  *  @copyright  Copyright (c) 2017-2018 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
@@ -44,11 +45,12 @@ class LSCacheComponentKomento extends LSCacheComponentBase{
     }
     
     protected function purgeComment($ids){
+            $ids = array_map('intval', $ids);
             $db = Factory::getDbo();
             $query = $db->createQuery()
                     ->select("distinct component, cid")
                     ->from('#__komento_comments')
-                    ->where($db->quoteName('id') . ' in (' . implode(',', $ids) . ')');
+                    ->where($db->quoteName('id') . ' IN (' . implode(',', $ids) . ')');
             $db->setQuery($query);
             $comments = $db->loadObjectList();
             foreach($comments as $comment){

--- a/Joomla6/lscache_plugin/components/com_virtuemart.php
+++ b/Joomla6/lscache_plugin/components/com_virtuemart.php
@@ -85,7 +85,8 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
     public function plgVmAfterStoreProduct($data, $product_data=null)
     {
         if($data instanceof Event) {
-            return $this->plgVmOnDeleteProduct($data->getArgument('0'), $data->getArgument('1'));
+            $product_data = $data->getArgument('1');
+            $data = $data->getArgument('0');
         }
 
         $category_tag = $this->getProductCategoryTags($product_data->virtuemart_product_id);
@@ -155,7 +156,7 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
             $this->plugin->purgeAction();
             return;
         }
-        $urls = $this->getProductCategoryUrls($id);
+        $urls = $this->getProductCategoryUrls($productids);
         $this->plugin->purgeObject->urls = array_merge($urls, $productUrls);
         $this->plugin->purgeAction();
     }
@@ -187,7 +188,7 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
         if ($context == "com_virtuemart.productdetails") {
             return 'com_virtuemart.product:' . $pageElements['content']->virtuemart_product_id;
         } else if ($context == "com_virtuemart.category") {
-            if (isset($pageElements["content"]) & !empty($pageElements["content"]->virtuemart_category_id)) {
+            if (isset($pageElements["content"]) && !empty($pageElements["content"]->virtuemart_category_id)) {
                 return 'com_virtuemart.category:' . $pageElements["content"]->virtuemart_category_id;
             }
             return $option;
@@ -203,8 +204,8 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
                 ->select($db->quoteName(array('virtuemart_category_id', 'virtuemart_product_id')))
                 ->from('#__virtuemart_product_categories');
         if (is_array($productid)) {
-            $products = implode(',', $productid);
-            $query->where($db->quoteName('virtuemart_product_id') . ' in (' . $products . ')');
+            $products = implode(',', array_map('intval', $productid));
+            $query->where($db->quoteName('virtuemart_product_id') . ' IN (' . $products . ')');
         } else {
             $query->where($db->quoteName('virtuemart_product_id') . '=' . (int) $productid);
         }
@@ -299,6 +300,10 @@ class LSCacheComponentVirtueMart extends LSCacheComponentBase
     public function onContentPrepare($context, $row=null, $params=null, $page = 0) {
         if($context instanceof Event) {
             return $this->onContentPrepare($context->getArgument(0),$context->getArgument(1),$context->getArgument(2),$context->getArgument(3));
+        }
+
+        if (!class_exists('VmModel')) {
+            return;
         }
 
         $productModel = VmModel::getModel('Product');

--- a/Joomla6/lscache_plugin/lscachebase.php
+++ b/Joomla6/lscache_plugin/lscachebase.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * General function of communicating with LSWS Server for LSCache operations,
@@ -64,7 +65,7 @@ class LiteSpeedCacheBase
                         
             $tagStr = $prefix . trim($tag);
             if(!in_array($tagStr, $tagArray, false)){
-                array_push($tagArray, $tagStr);
+                $tagArray[] = $tagStr;
             }
         }
     }
@@ -197,7 +198,7 @@ class LiteSpeedCacheBase
             $this->tagsForSite($siteTags, $privateTags);
         }
         else{
-            array_push($siteTags,  'pvt');
+            $siteTags[] = 'pvt';
         }
         
         $LSheader = $this->tagCommand( self::CACHE_TAG ,  $siteTags);
@@ -239,19 +240,19 @@ class LiteSpeedCacheBase
     {
         if ($value == "") {
             if (isset($_COOKIE[self::VARY_COOKIE])) {
-                setcookie(self::VARY_COOKIE, "", '0', $path);
+                setcookie(self::VARY_COOKIE, "", 0, $path);
                 return false;
             }
             return true;
         }
         
         if(!isset($_COOKIE[self::VARY_COOKIE])){
-            setcookie(self::VARY_COOKIE, $value, '0', $path);
+            setcookie(self::VARY_COOKIE, $value, 0, $path);
             return false;
         }
 
         if($_COOKIE[self::VARY_COOKIE] != $value){
-            setcookie(self::VARY_COOKIE, $value, '0', $path);
+            setcookie(self::VARY_COOKIE, $value, 0, $path);
             return false;
         }
         

--- a/Joomla6/lscache_plugin/lscachecore.php
+++ b/Joomla6/lscache_plugin/lscachecore.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Core function of communicating with LSWS Server for LSCache operations
@@ -59,7 +60,7 @@ class LiteSpeedCacheCore extends LiteSpeedCacheBase
                         
             $tagStr = $prefix . $this->site_only_tag . trim($tag);
             if(!in_array($tagStr, $tagArray, false)){
-                array_push($tagArray, $tagStr);
+                $tagArray[] = $tagStr;
             }
         }
     }
@@ -107,7 +108,7 @@ class LiteSpeedCacheCore extends LiteSpeedCacheBase
         $this->liteSpeedHeader($LSheader);
 
         $siteTags = Array();
-        array_push($siteTags, $this->site_only_tag);
+        $siteTags[] = $this->site_only_tag;
         $this->tagsForSite($siteTags, $publicTags);
 
         $LSheader = $this->tagCommand( self::CACHE_TAG ,  $siteTags);
@@ -137,11 +138,11 @@ class LiteSpeedCacheCore extends LiteSpeedCacheBase
         $siteTags = Array();
         $this->tagsForSite($siteTags, $publicTags, "public:".$this->site_only_tag);
         if($publicTags!=""){
-            array_push($siteTags, "public:" . $this->site_only_tag);
+            $siteTags[] = "public:" . $this->site_only_tag;
         }
-        
+
         $this->tagsForSite($siteTags, $privateTags);
-        array_push($siteTags, $this->site_only_tag);
+        $siteTags[] = $this->site_only_tag;
         
         $LSheader = $this->tagCommand( self::CACHE_TAG ,  $siteTags);
         $this->liteSpeedHeader($LSheader);


### PR DESCRIPTION
…deprecated APIs, performance)

Bug fixes:
- Initialize $purgeTags and $httpcode before conditional use to avoid undefined-variable notices on PHP 8+
- Replace bitwise & with logical && in a boolean condition in crawlUrls()
- Fix $_SERVER key lookup: X-LSCACHE -> HTTP_X_LSCACHE, matching PHP's header-to-superglobal naming convention (LITESPEED_ALLOWED was never being defined via the ADC detection path without this)
- Fix setcookie() expires argument: string '0' -> int 0 for PHP 8 typing
- plgVmAfterStoreProduct() was dispatching Joomla Event objects straight into plgVmOnDeleteProduct(); now correctly extracts $data/$product_data from the event arguments
- Fix undefined $id in plgVmConfirmedOrder(), replaced with $productids
- Guard onContentPrepare() with class_exists('VmModel') so VirtueMart 4.x (which dropped VmModel/VmPagination) doesn't hit a fatal error

Security:
- Cast IDs to int before building the SQL IN() clause in purgeComment()
- Validate base64_decode() output in purgeExtension(): reject false, path-traversal sequences, and null bytes before use
- Drop trust in spoofable HTTP_CLIENT_IP / HTTP_X_FORWARDED_FOR in getVisitorIP(); use REMOTE_ADDR validated with filter_var()
- Fix loose != comparisons to !== on password checks (type-juggling)
- Use $db->quote() instead of manual string concatenation in WHERE clauses
- array_map('intval') before implode() in getProductCategories()'s IN clause

Deprecated APIs:
- Replace JLoader::register() with require_once
- Replace jexit() with Session::checkToken() + $app->close(403)
- Fix Uri::getinstance() casing to Uri::getInstance() for consistency

Performance:
- Save/restore max_execution_time around set_time_limit(0) in crawlUrls() instead of leaving it permanently unlimited for the rest of the process
- Remove curl_close() calls (no-op since PHP 8.0, deprecated in PHP 8.5)
- purgeURLs() now fires all PURGE requests in parallel via curl_multi instead of sequentially, so purge time no longer scales with URL count

Applies identically to Joomla5/ and Joomla6/.