### PR TITLE
Add a HikaShop integration so shop pages are not cached for guests

### DIFF
--- a/Joomla3/lscache_plugin/components/com_hikashop.php
+++ b/Joomla3/lscache_plugin/components/com_hikashop.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *  @since      1.5.3
+ *  @author     LiteSpeed Technologies <info@litespeedtech.com>
+ *  @copyright  Copyright (c) 2017-2018 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ *  @license    https://opensource.org/licenses/GPL-3.0
+ */
+
+
+class LSCacheComponentHikaShop extends LSCacheComponentBase
+{
+    // The other views of HikaShop display the cart of the visitor or need his session token
+    protected $cachableViews = array('product', 'category');
+
+    public function onRegisterEvents()
+    {
+        // A visitor who has a cart sees it in the cart module, which can be displayed on any page
+        if (!empty($_COOKIE['hikashop_cart_id']) || !empty($_COOKIE['hikashop_wishlist_id'])) {
+            $this->plugin->pageCachable = false;
+            return;
+        }
+
+        if (!in_array($this->getView(), $this->cachableViews)) {
+            $this->plugin->pageCachable = false;
+        }
+    }
+
+    protected function getView()
+    {
+        $app = JFactory::getApplication();
+
+        // HikaShop uses "ctrl", and falls back on "view" for the links built by Joomla
+        $view = $app->input->getCmd('ctrl', '');
+        if ($view === '') {
+            $view = $app->input->getCmd('view', '');
+        }
+        if ($view === '' && isset($this->plugin->pageElements['view'])) {
+            $view = $this->plugin->pageElements['view'];
+        }
+
+        return $view;
+    }
+}

--- a/Joomla3/lscache_plugin/components/list.php
+++ b/Joomla3/lscache_plugin/components/list.php
@@ -13,4 +13,5 @@ $lscacheComponents = Array(
     "com_virtuemart" => Array("VirtueMart", "com_virtuemart", "com_virtuemart.php", "LSCacheComponentVirtueMart"),
     "com_sppagebuilder" => Array("SP Page Builder", "com_sppagebuilder", "com_sppagebuilder.php", "LSCacheComponentSPPageBuilder"),
     "com_komento" => Array("Komento", "com_komento", "com_komento.php", "LSCacheComponentKomento"),
+    "com_hikashop" => Array("HikaShop", "com_hikashop", "com_hikashop.php", "LSCacheComponentHikaShop"),
 );

--- a/Joomla4/lscache_plugin/components/com_hikashop.php
+++ b/Joomla4/lscache_plugin/components/com_hikashop.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *  @since      1.5.3
+ *  @author     LiteSpeed Technologies <info@litespeedtech.com>
+ *  @copyright  Copyright (c) 2017-2018 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ *  @license    https://opensource.org/licenses/GPL-3.0
+ */
+use Joomla\CMS\Factory;
+
+class LSCacheComponentHikaShop extends LSCacheComponentBase
+{
+    // The other views of HikaShop display the cart of the visitor or need his session token
+    protected $cachableViews = array('product', 'category');
+
+    public function onRegisterEvents()
+    {
+        // A visitor who has a cart sees it in the cart module, which can be displayed on any page
+        if (!empty($_COOKIE['hikashop_cart_id']) || !empty($_COOKIE['hikashop_wishlist_id'])) {
+            $this->plugin->pageCachable = false;
+            return;
+        }
+
+        if (!in_array($this->getView(), $this->cachableViews)) {
+            $this->plugin->pageCachable = false;
+        }
+    }
+
+    protected function getView()
+    {
+        $app = Factory::getApplication();
+
+        // HikaShop uses "ctrl", and falls back on "view" for the links built by Joomla
+        $view = $app->input->getCmd('ctrl', '');
+        if ($view === '') {
+            $view = $app->input->getCmd('view', '');
+        }
+        if ($view === '' && isset($this->plugin->pageElements['view'])) {
+            $view = $this->plugin->pageElements['view'];
+        }
+
+        return $view;
+    }
+}

--- a/Joomla4/lscache_plugin/components/list.php
+++ b/Joomla4/lscache_plugin/components/list.php
@@ -14,4 +14,5 @@ $lscacheComponents = Array(
     "com_sppagebuilder" => Array("SP Page Builder", "com_sppagebuilder", "com_sppagebuilder.php", "LSCacheComponentSPPageBuilder",0),
     "com_komento" => Array("Komento", "com_komento", "com_komento.php", "LSCacheComponentKomento",1),
     "com_content" => Array("Content", "com_content", "com_content.php", "LSCacheComponentContent",1),
+    "com_hikashop" => Array("HikaShop", "com_hikashop", "com_hikashop.php", "LSCacheComponentHikaShop",0),
 );

--- a/Joomla5/lscache_plugin/components/com_hikashop.php
+++ b/Joomla5/lscache_plugin/components/com_hikashop.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *  @since      1.5.3
+ *  @author     LiteSpeed Technologies <info@litespeedtech.com>
+ *  @copyright  Copyright (c) 2017-2018 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ *  @license    https://opensource.org/licenses/GPL-3.0
+ */
+use Joomla\CMS\Factory;
+
+class LSCacheComponentHikaShop extends LSCacheComponentBase
+{
+    // The other views of HikaShop display the cart of the visitor or need his session token
+    protected $cachableViews = array('product', 'category');
+
+    public function onRegisterEvents()
+    {
+        // A visitor who has a cart sees it in the cart module, which can be displayed on any page
+        if (!empty($_COOKIE['hikashop_cart_id']) || !empty($_COOKIE['hikashop_wishlist_id'])) {
+            $this->plugin->pageCachable = false;
+            return;
+        }
+
+        if (!in_array($this->getView(), $this->cachableViews)) {
+            $this->plugin->pageCachable = false;
+        }
+    }
+
+    protected function getView()
+    {
+        $app = Factory::getApplication();
+
+        // HikaShop uses "ctrl", and falls back on "view" for the links built by Joomla
+        $view = $app->input->getCmd('ctrl', '');
+        if ($view === '') {
+            $view = $app->input->getCmd('view', '');
+        }
+        if ($view === '' && isset($this->plugin->pageElements['view'])) {
+            $view = $this->plugin->pageElements['view'];
+        }
+
+        return $view;
+    }
+}

--- a/Joomla5/lscache_plugin/components/list.php
+++ b/Joomla5/lscache_plugin/components/list.php
@@ -14,4 +14,5 @@ $lscacheComponents = Array(
     "com_sppagebuilder" => Array("SP Page Builder", "com_sppagebuilder", "com_sppagebuilder.php", "LSCacheComponentSPPageBuilder",0),
     "com_komento" => Array("Komento", "com_komento", "com_komento.php", "LSCacheComponentKomento",1),
     "com_content" => Array("Content", "com_content", "com_content.php", "LSCacheComponentContent",1),
+    "com_hikashop" => Array("HikaShop", "com_hikashop", "com_hikashop.php", "LSCacheComponentHikaShop",0),
 );

--- a/Joomla6/lscache_plugin/components/com_hikashop.php
+++ b/Joomla6/lscache_plugin/components/com_hikashop.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *  @since      1.5.3
+ *  @author     LiteSpeed Technologies <info@litespeedtech.com>
+ *  @copyright  Copyright (c) 2017-2018 LiteSpeed Technologies, Inc. (https://www.litespeedtech.com)
+ *  @license    https://opensource.org/licenses/GPL-3.0
+ */
+use Joomla\CMS\Factory;
+
+class LSCacheComponentHikaShop extends LSCacheComponentBase
+{
+    // The other views of HikaShop display the cart of the visitor or need his session token
+    protected $cachableViews = array('product', 'category');
+
+    public function onRegisterEvents()
+    {
+        // A visitor who has a cart sees it in the cart module, which can be displayed on any page
+        if (!empty($_COOKIE['hikashop_cart_id']) || !empty($_COOKIE['hikashop_wishlist_id'])) {
+            $this->plugin->pageCachable = false;
+            return;
+        }
+
+        if (!in_array($this->getView(), $this->cachableViews)) {
+            $this->plugin->pageCachable = false;
+        }
+    }
+
+    protected function getView()
+    {
+        $app = Factory::getApplication();
+
+        // HikaShop uses "ctrl", and falls back on "view" for the links built by Joomla
+        $view = $app->input->getCmd('ctrl', '');
+        if ($view === '') {
+            $view = $app->input->getCmd('view', '');
+        }
+        if ($view === '' && isset($this->plugin->pageElements['view'])) {
+            $view = $this->plugin->pageElements['view'];
+        }
+
+        return $view;
+    }
+}

--- a/Joomla6/lscache_plugin/components/list.php
+++ b/Joomla6/lscache_plugin/components/list.php
@@ -14,4 +14,5 @@ $lscacheComponents = Array(
     "com_sppagebuilder" => Array("SP Page Builder", "com_sppagebuilder", "com_sppagebuilder.php", "LSCacheComponentSPPageBuilder",0),
     "com_komento" => Array("Komento", "com_komento", "com_komento.php", "LSCacheComponentKomento",1),
     "com_content" => Array("Content", "com_content", "com_content.php", "LSCacheComponentContent",1),
+    "com_hikashop" => Array("HikaShop", "com_hikashop", "com_hikashop.php", "LSCacheComponentHikaShop",0),
 );


### PR DESCRIPTION
HikaShop is a Joomla e-commerce component. Like VirtueMart, its frontend pages carry per visitor data: the cart module shows the cart of the current visitor, and the cart, checkout, account and order pages need the session token of that visitor to accept a form.

`com_hikashop` is not in `components/list.php`, so nothing stops the public cache from storing those pages. On a shop where LSCache is enabled without a manual exclusion, the result is that a guest is served a page built for another guest: the checkout then rejects the order with "Invalid Token", and the cart module can show a cart that is not his.

This adds `components/com_hikashop.php` (same shape as `com_virtuemart.php`) and registers it in `components/list.php` for Joomla 3, 4, 5 and 6.

Behaviour:

* product and category pages stay cachable, they are the pages worth caching on a shop
* every other HikaShop view (cart, checkout, user, address, order, ...) sets `pageCachable = false`
* any visitor who already has a cart sets `pageCachable = false` for every page, because the cart module can be displayed anywhere. HikaShop marks such a visitor with the `hikashop_cart_id` cookie it sets when the cart is created, so no query is needed.

No admin side hook is registered, so the entry uses `0` for the RUNADMIN flag.

The view names and the cookie were checked against a HikaShop 6.5 install on Joomla 6. We could not run a LiteSpeed server here, so the caching side has not been exercised end to end and a review is welcome.

Purging the cached product and category pages when a product is modified in the backend would be a good follow up, we are happy to send it as a second PR if you want it.
